### PR TITLE
chore: remove poetry-core from tool.poetry.extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,6 @@ black = { version = "^21.5b1", allow-prereleases = true }
 isort = {extras = ["requirements_deprecated_finder"], version = "^5.8.0"}
 
 [tool.poetry.extras]
-requires = ["poetry_core>=1.0.0"]
-build-backend = ["poetry.core.masonry.api"]
 testing = ["django-redis", "croniter", "hiredis", "psutil", "iron-mq", "boto3", "pymongo"]
 rollbar = ["django-q-rollbar"]
 sentry = ["django-q-sentry"]


### PR DESCRIPTION
it should be placed under the build system and not extras